### PR TITLE
use fs.readFileSync instead of require when loading json files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,10 @@ function isBoolean(value: any): value is boolean {
 	return value === true || value === false;
 }
 
+function readJsonFileSync<T = any>(filename: string): T {
+	return JSON.parse(fs.readFileSync(filename, 'utf8')) as T;
+}
+
 export enum MessageFormat {
 	file = 'file',
 	bundle = 'bundle',
@@ -148,8 +152,8 @@ function initializeSettings() {
 			if (isString(vscodeOptions._translationsConfigFile)) {
 				options.translationsConfigFile = vscodeOptions._translationsConfigFile;
 				try {
-					options.translationsConfig = require(options.translationsConfigFile);
-				} catch(error) {
+					options.translationsConfig = readJsonFileSync(options.translationsConfigFile);
+				} catch (error) {
 					// We can't read the translation config file. Mark the cache as corrupted.
 					if (vscodeOptions._corruptedFile) {
 						fs.writeFile(vscodeOptions._corruptedFile, 'corrupted', 'utf8', (err) => {
@@ -292,7 +296,7 @@ function mkdir(directory: string) {
 }
 
 function createDefaultNlsBundle(folder: string): NlsBundle {
-	let metaData: MetaDataFile = require(path.join(folder, 'nls.metadata.json'));
+	let metaData: MetaDataFile = readJsonFileSync(path.join(folder, 'nls.metadata.json'));
 	let result: NlsBundle = Object.create(null);
 	for (let module in metaData) {
 		let entry = metaData[module];
@@ -306,8 +310,8 @@ function createNLSBundle(header: MetadataHeader, metaDataPath: string): NlsBundl
 	if (!languagePackLocation) {
 		return undefined;
 	}
-	let languagePack: I18nBundle = require(languagePackLocation).contents;
-	let metaData: MetaDataFile = require(path.join(metaDataPath, 'nls.metadata.json'));
+	let languagePack: I18nBundle = readJsonFileSync(languagePackLocation).contents;
+	let metaData: MetaDataFile = readJsonFileSync(path.join(metaDataPath, 'nls.metadata.json'));
 	let result: NlsBundle = Object.create(null);
 	for (let module in metaData) {
 		let entry = metaData[module];
@@ -419,7 +423,7 @@ function loadNlsBundle(header: MetadataHeader, bundlePath: string): NlsBundle | 
 		let candidate = findInTheBoxBundle(bundlePath);
 		if (candidate) {
 			try {
-				return require(candidate);
+				return readJsonFileSync(candidate);
 			} catch (err) {
 				console.log(`Loading in the box message bundle failed.`, err);
 			}
@@ -496,7 +500,7 @@ export function loadMessageBundle(file?: string): LocalizeFunc {
 	if (options.messageFormat === MessageFormat.both || options.messageFormat === MessageFormat.file) {
 		// Try to load a single file bundle
 		try {
-			let json: SingleFileJsonFormat = require(resolveLanguage(file));
+			let json: SingleFileJsonFormat = readJsonFileSync(resolveLanguage(file));
 			if (Array.isArray(json)) {
 				return createScopedLocalizeFunction(json);
 			} else {
@@ -529,7 +533,7 @@ export function config(opts?: Options): LoadFunc {
 			resolvedBundles = Object.create(null);
 		}
 		if (opts.messageFormat !== undefined) {
-			options.messageFormat = opts.messageFormat;
+			options.messageFormat = opts.messageFormat;``
 		}
 	}
 	isPseudo = options.locale === 'pseudo';

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,7 +133,7 @@ let options: InternalOptions;
 let isPseudo: boolean;
 
 function initializeSettings() {
-	options = { locale: undefined, languagePackSupport: false, cacheLanguageResolution: true, messageFormat: MessageFormat.bundle};
+	options = { locale: undefined, languagePackSupport: false, cacheLanguageResolution: true, messageFormat: MessageFormat.bundle };
 	if (isString(process.env.VSCODE_NLS_CONFIG)) {
 		try {
 			let vscodeOptions = JSON.parse(process.env.VSCODE_NLS_CONFIG) as VSCodeNlsConfig;
@@ -178,7 +178,7 @@ function supportsLanguagePack(): boolean {
 }
 
 function format(message: string, args: any[]): string {
-	let result:string;
+	let result: string;
 
 	if (isPseudo) {
 		// FF3B and FF3D is the Unicode zenkaku representation for [ and ]
@@ -198,7 +198,7 @@ function format(message: string, args: any[]): string {
 
 
 function createScopedLocalizeFunction(messages: string[]): LocalizeFunc {
-	return function(key: any, message: string, ...args: any[]): string {
+	return function (key: any, message: string, ...args: any[]): string {
 		if (isNumber(key)) {
 			if (key >= messages.length) {
 				console.error(`Broken localize call found. Index out of bounds. Stacktrace is\n: ${(<any>new Error('')).stack}`);
@@ -230,7 +230,7 @@ function resolveLanguage(file: string): string {
 		} else {
 			let locale = options.locale;
 			while (locale) {
-				var candidate = '.nls.' + locale + '.json' ;
+				var candidate = '.nls.' + locale + '.json';
 				if (fs.existsSync(file + candidate)) {
 					resolvedLanguage = candidate;
 					break;
@@ -305,7 +305,7 @@ function createDefaultNlsBundle(folder: string): NlsBundle {
 	return result;
 }
 
-function createNLSBundle(header: MetadataHeader, metaDataPath: string): NlsBundle  | undefined {
+function createNLSBundle(header: MetadataHeader, metaDataPath: string): NlsBundle | undefined {
 	let languagePackLocation = options.translationsConfig[header.id];
 	if (!languagePackLocation) {
 		return undefined;
@@ -436,7 +436,7 @@ function loadNlsBundle(header: MetadataHeader, bundlePath: string): NlsBundle | 
 function tryFindMetaDataHeaderFile(file: string): string {
 	let result: string;
 	let dirname = path.dirname(file);
-	while(true) {
+	while (true) {
 		result = path.join(dirname, 'nls.metadata.header.json');
 		if (fs.existsSync(result)) {
 			break;
@@ -489,7 +489,7 @@ export function loadMessageBundle(file?: string): LocalizeFunc {
 				let messages = bundle.nlsBundle[module];
 				if (messages === undefined) {
 					console.error(`Messages for file ${file} not found. See console for details.`);
-					return function(): string {
+					return function (): string {
 						return 'Messages not found.';
 					}
 				}
@@ -520,7 +520,7 @@ export function loadMessageBundle(file?: string): LocalizeFunc {
 		}
 	}
 	console.error(`Failed to load message bundle for file ${file}`);
-	return function(): string {
+	return function (): string {
 		return 'Failed to load message bundle. See console for details.';
 	};
 }
@@ -533,7 +533,7 @@ export function config(opts?: Options): LoadFunc {
 			resolvedBundles = Object.create(null);
 		}
 		if (opts.messageFormat !== undefined) {
-			options.messageFormat = opts.messageFormat;``
+			options.messageFormat = opts.messageFormat;
 		}
 	}
 	isPseudo = options.locale === 'pseudo';


### PR DESCRIPTION
This PR is for #20 and uses `fs.readFileSync` instead of `require`. I reviewed the existing code carefully and replaced `require` with a new util function whenever we would have computed an absolute file path already. 