### PR TITLE
Fix broken typings for consumers (5.0.0-next.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
 	"browser": {
 		"./lib/node/main.js": "./lib/browser/main.js"
 	},
-	"typings": "./lib/common/common.d.ts",
 	"devDependencies": {
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^12.12.29",


### PR DESCRIPTION
I cloned `vscode-css-languageservice` locally to check `5.0.0-next.1` and noticed that the tests were breaking due to incorrect type definitions.
I removed the typings field from the `package.json` as TypeScript seemed to be able to find them regardless. 

With this changed locally, all tests in `vscode-css-languageservice` pass successfully.