### PR TITLE
Add null check for options.locale before calling toLowerCase

### DIFF
--- a/src/browser/main.ts
+++ b/src/browser/main.ts
@@ -20,7 +20,7 @@ export function loadMessageBundle(_file?: string) {
 }
 
 export function config(options?: Options) {
-	setPseudo(options?.locale.toLowerCase() === 'pseudo');
+	setPseudo(options?.locale?.toLowerCase() === 'pseudo');
 	return loadMessageBundle;
 }
 


### PR DESCRIPTION
In the Options object locale is optional:

https://github.com/microsoft/vscode-nls/blob/main/src/common/common.ts#L21

This PR adds a null check before calling toLowerCase on it.