### PR TITLE
Fixing bug that only allowed <= 9 formatting arguments

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -107,8 +107,7 @@ export function format(message: string, args: any[]): string {
 		result = message;
 	}
 	else {
-		result = message.replace(/\{(\d+)\}/g, (match, rest) => {
-			let index = rest[0];
+		result = message.replace(/{(\d+)}/g, (match, index) => {
 			let arg = args[index];
 			let replacement = match;
 			if (typeof arg === 'string') {


### PR DESCRIPTION
**Description**: While working on a derivative of this library, I noticed that the regex replace method for formatting localized strings was behaving strangely with a large number of formatting arguments. The format method uses the `String.prototype.replace` with a regular expression and a replacer function. The original signature of the replacer function was `(match, rest)` and the index of the formatting argument to use was `rest[0]`. According to the [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_function_as_a_parameter) each capture group of the regular expression is exposed as its own string argument to the replacer function. As such in the case of `{10}`, `rest` would be `"10"` and `index` would be calculated to be `"1"`. Meaning it's impossible to use >9 formatting arguments with the current implementation.

The proposed solution is to remove the separate assignment of `index` and instead use the capture group value in its entirety as the index.

**Testing**: I ran this code manually in my derivative project and it works successfully. Since there are no unit tests for the formatter, I was unable to test the formatter with unit tests.