### PR TITLE
Revert "Enable a mechanism for something to inject data into vscode-nls (#42)" due to breaking extensions.

### DIFF
--- a/src/browser/main.ts
+++ b/src/browser/main.ts
@@ -5,80 +5,23 @@
 
 import RAL from '../common/ral';
 
-import { setPseudo, localize, Options, LocalizeInfo, isString, MessageFormat, isNumber, format, LocalizeFunc } from '../common/common';
+import { setPseudo, localize, Options, LocalizeInfo } from '../common/common';
+
 export { MessageFormat, BundleFormat, Options, LocalizeInfo, LocalizeFunc, LoadFunc, KeyInfo } from '../common/common';
 
-let nlsData: { [key: string]: string[] };
-try {
-	// Requiring this file will be intercepted by VS Code and will contain actual NLS data.
-	// @ts-ignore
-	nlsData = require('vscode-nls-web-data');
-} catch(e) {
-	console.error('Loading vscode-nls-web-data failed. Are you running this outside of VS Code? If so, you may need to intercept the import call with your bundled NLS data.');
-	nlsData = {};
-}
-
-interface InternalOptions {
-	locale: string | undefined;
-	language: string | undefined;
-	languagePackSupport: boolean;
-	cacheLanguageResolution: boolean;
-	messageFormat: MessageFormat;
-	languagePackId?: string;
-	cacheRoot?: string;
-}
-
-let options: InternalOptions;
-
-export function loadMessageBundle(file?: string) {
-	if (!file) {
-		// No file. We are in dev mode. Return the default
-		// localize function.
-		return localize;
-	}
-	// Remove extension since we load json files.
-	if (file.endsWith('.js') || file.endsWith('.ts')) {
-		file = file.substring(0, file.length - 3);
-	}
-	if (file.startsWith('/')) {
-		file = file.substring(1);
-	}
-	if (nlsData && nlsData[file]) {
-		return createScopedLocalizeFunction(nlsData[file]);
-	}
+export function loadMessageBundle(_file?: string) {
 	return function (key: string | number | LocalizeInfo, message: string, ...args: any[]): string {
 		if (typeof key === 'number') {
-			throw new Error('Externalized strings were not present in the environment.');
+			throw new Error(`Browser implementation does currently not support externalized strings.`);
 		} else {
 			return localize(key, message, ...args);
 		}
 	};
 }
 
-// This API doesn't really do anything in practice because the message bundle _has_ to be loaded
-// ahead of time via 'vscode-nls-web-data'.
-export function config(opts?: Options) {
+export function config(options?: Options) {
 	setPseudo(options?.locale?.toLowerCase() === 'pseudo');
 	return loadMessageBundle;
-}
-
-function createScopedLocalizeFunction(messages: string[]): LocalizeFunc {
-	return function (key: any, message: string, ...args: any[]): string {
-		if (isNumber(key)) {
-			if (key >= messages.length) {
-				console.error(`Broken localize call found. Index out of bounds. Stacktrace is\n: ${(<any>new Error('')).stack}`);
-				return;
-			}
-			return format(messages[key], args);
-		} else {
-			if (isString(message)) {
-				console.warn(`Message ${message} didn't get externalized correctly.`);
-				return format(message, args);
-			} else {
-				console.error(`Broken localize call found. Stacktrace is\n: ${(<any>new Error('')).stack}`);
-			}
-		}
-	};
 }
 
 RAL.install(Object.freeze<RAL>({

--- a/src/browser/tsconfig.json
+++ b/src/browser/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "lib": [
-            "es2015",
+            "es5",
             "dom"
         ],
         "outDir": "../../lib/browser"

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -91,16 +91,6 @@ export function isDefined(value: any): boolean {
 	return typeof value !== 'undefined';
 }
 
-const toString = Object.prototype.toString;
-
-export function isNumber(value: any): value is number {
-	return toString.call(value) === '[object Number]';
-}
-
-export function isString(value: any): value is string {
-	return toString.call(value) === '[object String]';
-}
-
 export let isPseudo = false;
 
 export function setPseudo(pseudo: boolean) {

--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -10,10 +10,20 @@ import RAL from '../common/ral';
 
 import {
 	format, localize, isDefined, setPseudo, isPseudo, MessageFormat, BundleFormat, Options, TranslationConfig, LanguageBundle, LocalizeFunc,
-	NlsBundle, MetaDataFile, MetadataHeader, I18nBundle, SingleFileJsonFormat, LoadFunc, isString, isNumber
+	NlsBundle, MetaDataFile, MetadataHeader, I18nBundle, SingleFileJsonFormat, LoadFunc
 } from '../common/common';
 
 export { MessageFormat, BundleFormat, Options, LocalizeInfo, LocalizeFunc, LoadFunc, KeyInfo } from '../common/common';
+
+const toString = Object.prototype.toString;
+
+function isNumber(value: any): value is number {
+	return toString.call(value) === '[object Number]';
+}
+
+function isString(value: any): value is string {
+	return toString.call(value) === '[object String]';
+}
 
 function isBoolean(value: any): value is boolean {
 	return value === true || value === false;


### PR DESCRIPTION
This reverts commit 0e2dbdbccebde6d647280c4b7429369061a2f291.

We are going in a different direction by having an official VS Code API to do this. Please see:
https://github.com/microsoft/vscode/pull/158328

Fixes #44