### PR TITLE
Add package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
 		"./lib/node/main.js": "./lib/browser/main.js"
 	},
 	"typings": "./lib/common/common.d.ts",
+	"exports": {
+		".": {
+			"browser": "./lib/browser/main.js",
+			"default": "./lib/node/main.js"
+		},
+		"./browser": "./lib/browser/main.js",
+		"./browser.js": "./lib/browser/main.js",
+		"./node": "./lib/node/main.js",
+		"./node.js": "./lib/node/main.js"
+	},
 	"devDependencies": {
 		"@types/mocha": "^9.1.0",
 		"@types/node": "14.14.31",
@@ -26,7 +36,7 @@
 		"typescript": "^4.5.5"
 	},
 	"scripts": {
-		"prepublishOnly": "npm run clean && npm run compile && npm run lint && npm run test",
+		"prepack": "npm run clean && npm run compile && npm run lint && npm run test",
 		"compile": "tsc -b ./tsconfig.json",
 		"watch": "tsc -b ./tsconfig.json -w",
 		"clean": "rimraf lib",


### PR DESCRIPTION
The `browser` export condition now resolves to browser code. Everything else resolves to the Node.js code. Also exports were added for `./browser` and `./node` with and without extensions, as it seems to be intentional to support those imports.